### PR TITLE
Fix for mhd/mha files

### DIFF
--- a/preprocessing/step1.py
+++ b/preprocessing/step1.py
@@ -84,7 +84,7 @@ def load_itk_image(path):
     pixel_data = sitk.GetArrayFromImage(sitk_image)
     preprocessing_info_file_name = os.path.join(
         os.environ.get("OUTPUT_DIR", "/output/"),
-        '{}_preprocessing_info.txt'.format(path))
+        '{}_preprocessing_info.txt'.format(os.path.basename(os.path.normpath(path))))
     if os.path.exists(preprocessing_info_file_name):
         os.remove(preprocessing_info_file_name)
     with open(preprocessing_info_file_name,


### PR DESCRIPTION
Closes: #12 
I just had to add support for itk images for conversion of the voxel coordinates into world coordinates. 
I tested individually with .mhd, .mha and folders containing .dcm files. Also, tested it with Sil's input folder /mnt/netcache/bodyct/temp/sil/grt123/inputs/ which contains a mixture of three types of files. Output is in /mnt/netcache/bodyct/temp/haimasree/sil_output/ 
I checked  output coordinates and they are identical across three types of input scans, as expected. Output prediction (prediction.csv) is also identical, as expected.

TODO:
- Update this submodule in the processor after merging
- Push the new processor
- More tests