### PR TITLE
Hotfix for xmlreport.py with converted 0.0.2 version from bodyct-nodule-evaluation

### DIFF
--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -22,8 +22,8 @@ ENV GIT_COMMIT_ID=$GIT_COMMIT_ID
 # first ensure that xmlreport.py matches the md5 hash version,
 # subsequently replace the GIT_COMMIT_ID lookup function with the embeded GIT_COMMIT_ID string
 # expects line endings to be LF
-RUN echo "ecaf1db67f153ec12f7068cc84eb1da6  /home/user/DSB2017/xmlreport.py" | md5sum -c -
-RUN python -c "fn='/home/user/DSB2017/xmlreport.py'; f=open(fn, 'r'); data=f.readlines(); f.close(); data=data[:9] + ['    return \"$GIT_COMMIT_ID\"\n'] + data[14:]; f=open(fn, 'w'); f.writelines(data); f.close();"
+RUN echo "419020b0fad961904cd6f20fd4a073c9  /home/user/DSB2017/xmlreport.py" | md5sum -c -
+RUN python -c "fn='/home/user/DSB2017/xmlreport.py'; f=open(fn, 'r'); data=f.readlines(); f.close(); data=data[:10] + ['    return \"$GIT_COMMIT_ID\"\n'] + data[15:]; f=open(fn, 'w'); f.writelines(data); f.close();"
 
 USER root
 RUN chown user:user -R /home/user/DSB2017

--- a/tests/test_xmlreport.py
+++ b/tests/test_xmlreport.py
@@ -80,7 +80,7 @@ def test_full_report_generation():
         seriesuid="424.35",
     )
     cancerinfo = xmlreport.CancerInfo(
-        casecancerprobability=0.5, referencenoduleids=[1, 2, 3, 4, 5]
+        casecancerprobability=0.5, referencenoduleids=[0]
     )
 
     report = xmlreport.LungCadReport(
@@ -202,7 +202,7 @@ def test_equivalence_cancerinfo(casecancerprobability, referencenoduleids):
     [
         None,
         xmlreport.CancerInfo(
-            casecancerprobability=0.5, referencenoduleids=[1, 2, 3, 4, 5]
+            casecancerprobability=0.5, referencenoduleids=[0, 1, 2, 3]
         ),
     ],
 )

--- a/xmlreport.py
+++ b/xmlreport.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as et
+from datetime import datetime
 from xml.etree import ElementTree
 from xml.dom import minidom
 import re
@@ -16,38 +17,47 @@ def get_current_git_hash():
 
 class abstractstatic(staticmethod):
     __slots__ = ()
+
     def __init__(self, function):
         super(abstractstatic, self).__init__(function)
         function.__isabstractmethod__ = True
+
     __isabstractmethod__ = True
 
 
 def instanceofcheck(obj, typ):
     if not isinstance(obj, typ):
-        raise ValueError("Object type ({}) is not of type: {}".format(type(obj), typ))
+        raise ValueError(
+            "Object type ({}) is not of type: {}".format(type(obj), typ)
+        )
 
 
 def lencheck(obj, length):
     instanceofcheck(obj, (list, tuple))
     if not len(obj) == length:
-        raise ValueError("Object length is ({}), expected: {}".format(len(obj), length))
+        raise ValueError(
+            "Object length is ({}), expected: {}".format(len(obj), length)
+        )
 
 
 def matchcheck(obj, pattern):
     if not re.match(pattern, obj.strip()):
-        raise ValueError("{} does not match regex. pattern: {}".format(obj, pattern))
+        raise ValueError(
+            "{} does not match regex. pattern: {}".format(obj, pattern)
+        )
 
 
 def prettify(elem):
-    """Return a pretty-printed XML string for the Element.
-    """
-    rough_string = ElementTree.tostring(elem, 'utf-8')
+    """Return a pretty-printed XML string for the Element."""
+    rough_string = ElementTree.tostring(elem, "utf-8")
     reparsed = minidom.parseString(rough_string)
     return reparsed.toprettyxml(indent="  ")
 
 
 def none_str_guard(obj):
     if obj is None:
+        return ""
+    elif obj.lower() == "unknown":
         return ""
     return obj
 
@@ -66,6 +76,16 @@ class XMLGeneratable(object):
     @abstractstatic
     def from_xml(xml):
         raise NotImplementedError()
+
+    @classmethod
+    def from_file(cls, fname):
+        return cls.from_xml(ElementTree.parse(str(fname)))
+
+    def to_file(self, fname):
+        with open(str(fname), "wb") as f:
+            ElementTree.ElementTree(self.xml_element()).write(
+                f, encoding="UTF-8", xml_declaration=True
+            )
 
 
 class LungCadReport(XMLGeneratable):
@@ -87,7 +107,7 @@ class LungCadReport(XMLGeneratable):
             finding.validate()
         if self.cancerinfo is not None:
             instanceofcheck(self.cancerinfo, CancerInfo)
-            self.cancerinfo.validate()
+            self.cancerinfo.validate(findings=self.findings)
 
     def xml_element(self):
         self.validate()
@@ -111,70 +131,121 @@ class LungCadReport(XMLGeneratable):
         findings = []
         for child in xml.findall("./Findings/Finding"):
             findings.append(Finding.from_xml(child))
-        return LungCadReport(lungcad, imageinfo, findings, cancerinfo=cancerinfo)
+        return LungCadReport(
+            lungcad, imageinfo, findings, cancerinfo=cancerinfo
+        )
 
     def __eq__(self, other):
-        return isinstance(other, type(self)) and \
-               self.lungcad == other.lungcad and \
-               self.imageinfo == other.imageinfo and \
-               self.cancerinfo == other.cancerinfo and \
-               len(self.findings) == len(other.findings) and \
-               all([f1 == f2 for f1, f2 in zip(self.findings, other.findings)])
+        return (
+            isinstance(other, type(self))
+            and self.lungcad == other.lungcad
+            and self.imageinfo == other.imageinfo
+            and self.cancerinfo == other.cancerinfo
+            and len(self.findings) == len(other.findings)
+            and all(
+                [f1 == f2 for f1, f2 in zip(self.findings, other.findings)]
+            )
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "LungCAD: {}\nImageInfo: {}\nCancerInfo: {}\nFindings:{}".format(self.lungcad, self.imageinfo, self.cancerinfo, self.findings)
+        return "LungCAD: {}\nImageInfo: {}\nCancerInfo: {}\nFindings:{}".format(
+            self.lungcad, self.imageinfo, self.cancerinfo, self.findings
+        )
 
 
 class LungCad(XMLGeneratable):
-    def __init__(self, revision, name, datetimeofexecution, trainingset1, trainingset2,
-                 coordinatesystem, computationtimeinseconds):
+    def __init__(
+        self,
+        revision,
+        name,
+        datetimeofexecution,
+        trainingset1,
+        trainingset2,
+        coordinatesystem,
+        computationtimeinseconds,
+    ):
         self.revision = revision
         self.name = name
-        self.datetimeofexecution = datetimeofexecution
+        self.datetimeofexecution = (
+            datetimeofexecution.strftime("%Y-%m-%d %H:%M:%S")
+            if isinstance(datetimeofexecution, datetime)
+            else datetimeofexecution
+        )
         self.trainingset1 = trainingset1
         self.trainingset2 = trainingset2
         self.coordinatesystem = coordinatesystem
         self.computationtimeinseconds = computationtimeinseconds
 
     def validate(self):
-        for attr in ["revision", "name", "datetimeofexecution", "trainingset1", "trainingset2", "coordinatesystem"]:
+        for attr in [
+            "revision",
+            "name",
+            "trainingset1",
+            "trainingset2",
+            "coordinatesystem",
+        ]:
             instanceofcheck(getattr(self, attr), str)
-        assert len(self.name) > 0
-        matchcheck(self.datetimeofexecution, r"^\d\d/\d\d/\d\d\d\d\s\d\d:\d\d:\d\d$")
-        matchcheck(self.revision, r"^[0-9a-f]{40}$")
-        matchcheck(self.coordinatesystem, r"^World$")
+        if self.datetimeofexecution != "":
+            matchcheck(
+                self.datetimeofexecution,
+                r"^(\d\d\d\d-(\d\d|[A-Z][a-z]{2})-\d\d|\d\d/\d\d/\d\d\d\d)\s\d\d:\d\d:\d\d(\.\d\d\d\d\d\d)?$",
+            )
+        if self.revision != "":
+            matchcheck(self.revision.lower(), r"^[0-9a-f]{40}$")
+        matchcheck(self.coordinatesystem.lower(), r"^world$")
         instanceofcheck(self.computationtimeinseconds, (int, float))
 
     def xml_element(self):
         info = et.Element("LungCAD")
-        for attr in ["Revision", "Name", "DateTimeOfExecution", "TrainingSet1", "TrainingSet2", "CoordinateSystem", "ComputationTimeInSeconds"]:
+        for attr in [
+            "Revision",
+            "Name",
+            "DateTimeOfExecution",
+            "TrainingSet1",
+            "TrainingSet2",
+            "CoordinateSystem",
+            "ComputationTimeInSeconds",
+        ]:
             et.SubElement(info, attr).text = str(getattr(self, attr.lower()))
         return info
 
     @staticmethod
     def from_xml(xml):
-        revision = xml.find("./Revision").text
-        name = xml.find("./Name").text
-        datetimeofexecution = xml.find("./DateTimeOfExecution").text
+        revision = none_str_guard(xml.find("./Revision").text)
+        name = none_str_guard(xml.find("./Name").text)
+        datetimeofexecution = none_str_guard(
+            xml.find("./DateTimeOfExecution").text
+        )
         trainingset1 = none_str_guard(xml.find("./TrainingSet1").text)
         trainingset2 = none_str_guard(xml.find("./TrainingSet2").text)
         coordinatesystem = xml.find("./CoordinateSystem").text
-        computationtimeinseconds = float(xml.find("./ComputationTimeInSeconds").text)
-        return LungCad(revision, name, datetimeofexecution, trainingset1, trainingset2,
-                       coordinatesystem, computationtimeinseconds)
+        computationtimeinseconds = float(
+            xml.find("./ComputationTimeInSeconds").text
+        )
+        return LungCad(
+            revision,
+            name,
+            datetimeofexecution,
+            trainingset1,
+            trainingset2,
+            coordinatesystem,
+            computationtimeinseconds,
+        )
 
     def __eq__(self, other):
-        return isinstance(other, type(self)) and \
-               self.revision == other.revision and \
-               self.name == other.name and \
-               self.datetimeofexecution == other.datetimeofexecution and \
-               self.trainingset1 == other.trainingset1 and \
-               self.trainingset2 == other.trainingset2 and \
-               self.coordinatesystem == other.coordinatesystem and \
-               self.computationtimeinseconds == other.computationtimeinseconds
+        return (
+            isinstance(other, type(self))
+            and self.revision == other.revision
+            and self.name == other.name
+            and self.datetimeofexecution == other.datetimeofexecution
+            and self.trainingset1 == other.trainingset1
+            and self.trainingset2 == other.trainingset2
+            and self.coordinatesystem == other.coordinatesystem
+            and self.computationtimeinseconds == other.computationtimeinseconds
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -187,11 +258,24 @@ class LungCad(XMLGeneratable):
             self.trainingset1,
             self.trainingset2,
             self.coordinatesystem,
-            self.computationtimeinseconds)
+            self.computationtimeinseconds,
+        )
 
 
 class Finding(XMLGeneratable):
-    def __init__(self, id, x, y, z, probability, diameter_mm, volume_mm3, extent=None, cancerprobability=None):
+    def __init__(
+        self,
+        id,
+        x,
+        y,
+        z,
+        probability,
+        diameter_mm,
+        volume_mm3,
+        extent=None,
+        cancerprobability=None,
+        noduletype=None,
+    ):
         self.id = id
         self.x = x
         self.y = y
@@ -203,10 +287,18 @@ class Finding(XMLGeneratable):
         if self.extent is not None:
             self.extent = tuple(extent)
         self.cancerprobability = cancerprobability
+        self.noduletype = noduletype
 
     def validate(self):
         instanceofcheck(self.id, int)
-        for var in [self.x, self.y, self.z, self.probability, self.diameter_mm, self.volume_mm3]:
+        for var in [
+            self.x,
+            self.y,
+            self.z,
+            self.probability,
+            self.diameter_mm,
+            self.volume_mm3,
+        ]:
             instanceofcheck(var, (int, float))
         if self.cancerprobability is not None:
             instanceofcheck(self.cancerprobability, (int, float))
@@ -214,20 +306,42 @@ class Finding(XMLGeneratable):
             lencheck(self.extent, 3)
             for element in self.extent:
                 instanceofcheck(element, (int, float))
+        if self.noduletype is not None:
+            instanceofcheck(self.noduletype, str)
 
     def xml_element(self):
         finding = et.Element("Finding")
-        for attr in ["ID", "X", "Y", "Z", "Extent", "Probability", "CancerProbability", "Diameter_mm", "Volume_mm3"]:
+        for attr in [
+            "ID",
+            "X",
+            "Y",
+            "Z",
+            "Extent",
+            "Probability",
+            "CancerProbability",
+            "Diameter_mm",
+            "Volume_mm3",
+            "NoduleType",
+        ]:
             if attr == "CancerProbability":
                 if self.cancerprobability is not None:
-                    et.SubElement(finding, attr).text = str(self.cancerprobability)
+                    et.SubElement(finding, attr).text = str(
+                        self.cancerprobability
+                    )
+            elif attr == "NoduleType":
+                if self.noduletype is not None:
+                    et.SubElement(finding, attr).text = self.noduletype
             elif attr == "Extent":
                 if self.extent is not None:
                     ext = et.SubElement(finding, "Extent")
                     for e, idx in zip(self.extent, ["X", "Y", "Z"]):
-                        et.SubElement(ext, "Extent{}".format(idx)).text = str(e)
+                        et.SubElement(ext, "Extent{}".format(idx)).text = str(
+                            e
+                        )
             else:
-                et.SubElement(finding, attr).text = str(getattr(self, attr.lower()))
+                et.SubElement(finding, attr).text = str(
+                    getattr(self, attr.lower())
+                )
         return finding
 
     @staticmethod
@@ -244,39 +358,75 @@ class Finding(XMLGeneratable):
             cancerprobability = float(cancerprobability.text)
         extent = xml.find("./Extent")
         if extent is not None:
-            extent = tuple([float(xml.find("./Extent/Extent{}".format(element)).text) for element in ["X", "Y", "Z"]])
-        return Finding(id, x, y, z, probability, diameter_mm, volume_mm3, cancerprobability=cancerprobability, extent=extent)
+            extent = tuple(
+                [
+                    float(xml.find("./Extent/Extent{}".format(element)).text)
+                    for element in ["X", "Y", "Z"]
+                ]
+            )
+        noduletype = xml.find("./NoduleType")
+        if noduletype is not None:
+            noduletype = noduletype.text
+        return Finding(
+            id,
+            x,
+            y,
+            z,
+            probability,
+            diameter_mm,
+            volume_mm3,
+            cancerprobability=cancerprobability,
+            extent=extent,
+            noduletype=noduletype,
+        )
 
     def __eq__(self, other):
-        return isinstance(other, type(self)) and \
-               self.id == other.id and \
-               self.x == other.x and \
-               self.y == other.y and \
-               self.z == other.z and \
-               self.extent == other.extent and \
-               self.probability == other.probability and \
-               self.cancerprobability == other.cancerprobability and \
-               self.diameter_mm == other.diameter_mm and \
-               self.volume_mm3 == other.volume_mm3
+        return (
+            isinstance(other, type(self))
+            and self.id == other.id
+            and self.x == other.x
+            and self.y == other.y
+            and self.z == other.z
+            and self.extent == other.extent
+            and self.probability == other.probability
+            and self.cancerprobability == other.cancerprobability
+            and self.diameter_mm == other.diameter_mm
+            and self.volume_mm3 == other.volume_mm3
+            and self.noduletype == other.noduletype
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "id: {} x: {} y: {} z: {} extent: {} probability: {} cancerprobability: {} diameter_mm: {} volume_mm3: {}".format(
-            self.id,
-            self.x,
-            self.y,
-            self.z,
-            self.extent,
-            self.probability,
-            self.cancerprobability,
-            self.diameter_mm,
-            self.volume_mm3)
+        return (
+            "id: {} x: {} y: {} z: {} extent: {} probability: {} "
+            "cancerprobability: {} diameter_mm: {} volume_mm3: {}  noduletype: {}".format(
+                self.id,
+                self.x,
+                self.y,
+                self.z,
+                self.extent,
+                self.probability,
+                self.cancerprobability,
+                self.diameter_mm,
+                self.volume_mm3,
+                self.noduletype,
+            )
+        )
 
 
 class ImageInfo(XMLGeneratable):
-    def __init__(self, dimensions, voxelsize, origin, orientation, patientuid, studyuid, seriesuid):
+    def __init__(
+        self,
+        dimensions,
+        voxelsize,
+        origin,
+        orientation,
+        patientuid,
+        studyuid,
+        seriesuid,
+    ):
         self.dimensions = dimensions
         self.voxelsize = voxelsize
         self.origin = origin
@@ -286,7 +436,11 @@ class ImageInfo(XMLGeneratable):
         self.seriesuid = seriesuid
 
     def validate(self):
-        for var, typ in ((self.dimensions, int), (self.voxelsize, (int, float)), (self.origin, (int, float))):
+        for var, typ in (
+            (self.dimensions, int),
+            (self.voxelsize, (int, float)),
+            (self.origin, (int, float)),
+        ):
             lencheck(var, 3)
             for element in var:
                 instanceofcheck(element, typ)
@@ -295,16 +449,24 @@ class ImageInfo(XMLGeneratable):
             instanceofcheck(element, (int, float))
         for var in (self.patientuid, self.studyuid):
             instanceofcheck(var, str)
-            matchcheck(var, r"^[\d.]*$")
+            matchcheck(var, r"^([\d.]*|None)$")
         instanceofcheck(self.seriesuid, str)
 
     def xml_element(self):
         info = et.Element("ImageInfo")
-        for attr, subattr in (("Dimensions", "dim"), ("VoxelSize", "voxelSize"), ("Origin", "origin")):
+        for attr, subattr in (
+            ("Dimensions", "dim"),
+            ("VoxelSize", "voxelSize"),
+            ("Origin", "origin"),
+        ):
             sub = et.SubElement(info, attr)
             for idx, element in enumerate(["X", "Y", "Z"]):
-                et.SubElement(sub, "{}{}".format(subattr, element)).text = str(getattr(self, attr.lower())[idx])
-        et.SubElement(info, "Orientation").text = ",".join([str(e) for e in self.orientation])
+                et.SubElement(sub, "{}{}".format(subattr, element)).text = str(
+                    getattr(self, attr.lower())[idx]
+                )
+        et.SubElement(info, "Orientation").text = ",".join(
+            [str(e) for e in self.orientation]
+        )
         for attr in ["PatientUID", "StudyUID", "SeriesUID"]:
             et.SubElement(info, attr).text = str(getattr(self, attr.lower()))
         return info
@@ -312,37 +474,66 @@ class ImageInfo(XMLGeneratable):
     @staticmethod
     def from_xml(xml):
         t = {}
-        for attr, subattr, typ in (("Dimensions", "dim", int), ("VoxelSize", "voxelSize", float), ("Origin", "origin", float)):
-            t[attr.lower()] = tuple([typ(xml.find("./{}/{}{}".format(attr, subattr, element)).text) for element in ["X", "Y", "Z"]])
-        orientation = tuple([float(e) for e in xml.find("./Orientation").text.split(',')])
+        for attr, subattr, typ in (
+            ("Dimensions", "dim", int),
+            ("VoxelSize", "voxelSize", float),
+            ("Origin", "origin", float),
+        ):
+            t[attr.lower()] = tuple(
+                [
+                    typ(
+                        xml.find(
+                            "./{}/{}{}".format(attr, subattr, element)
+                        ).text
+                    )
+                    for element in ["X", "Y", "Z"]
+                ]
+            )
+        orientation = tuple(
+            [float(e) for e in xml.find("./Orientation").text.split(",")]
+        )
         patientuid = none_str_guard(xml.find("./PatientUID").text)
         studyuid = none_str_guard(xml.find("./StudyUID").text)
         seriesuid = xml.find("./SeriesUID").text
         patientuid = patientuid if patientuid is not None else ""
-        return ImageInfo(t["dimensions"], t["voxelsize"], t["origin"], orientation, patientuid, studyuid, seriesuid)
+        return ImageInfo(
+            t["dimensions"],
+            t["voxelsize"],
+            t["origin"],
+            orientation,
+            patientuid,
+            studyuid,
+            seriesuid,
+        )
 
     def __eq__(self, other):
-        return isinstance(other, type(self)) and \
-               self.dimensions == other.dimensions and \
-               self.voxelsize == other.voxelsize and \
-               self.origin == other.origin and \
-               self.orientation == other.orientation and \
-               self.patientuid == other.patientuid and \
-               self.studyuid == other.studyuid and \
-               self.seriesuid == other.seriesuid
+        return (
+            isinstance(other, type(self))
+            and self.dimensions == other.dimensions
+            and self.voxelsize == other.voxelsize
+            and self.origin == other.origin
+            and self.orientation == other.orientation
+            and self.patientuid == other.patientuid
+            and self.studyuid == other.studyuid
+            and self.seriesuid == other.seriesuid
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "dimensions: {} voxelsize: {} origin: {} orientation: {} patientuid: {} studyuid: {} seriesuid: {}".format(
-            self.dimensions,
-            self.voxelsize,
-            self.origin,
-            self.orientation,
-            self.patientuid,
-            self.studyuid,
-            self.seriesuid)
+        return (
+            "dimensions: {} voxelsize: {} origin: {} orientation: {} "
+            "patientuid: {} studyuid: {} seriesuid: {}".format(
+                self.dimensions,
+                self.voxelsize,
+                self.origin,
+                self.orientation,
+                self.patientuid,
+                self.studyuid,
+                self.seriesuid,
+            )
+        )
 
 
 class CancerInfo(XMLGeneratable):
@@ -350,33 +541,55 @@ class CancerInfo(XMLGeneratable):
         self.casecancerprobability = casecancerprobability
         self.referencenoduleids = tuple(referencenoduleids)
 
-    def validate(self):
+    def validate(self, findings=None):
         instanceofcheck(self.casecancerprobability, (int, float))
         instanceofcheck(self.referencenoduleids, (list, tuple))
         for e in self.referencenoduleids:
             instanceofcheck(e, int)
+        if findings is not None:
+            findings_ids = set([finding.id for finding in findings])
+            for e in self.referencenoduleids:
+                if e not in findings_ids:
+                    raise ValueError(
+                        "Reference nodule id {} was not found "
+                        "in findings".format(e)
+                    )
 
     def xml_element(self):
         info = et.Element("CancerInfo")
-        et.SubElement(info, "CaseCancerProbability").text = str(self.casecancerprobability)
-        et.SubElement(info, "ReferenceNoduleIDs").text = ",".join([str(e) for e in self.referencenoduleids])
+        et.SubElement(info, "CaseCancerProbability").text = str(
+            self.casecancerprobability
+        )
+        et.SubElement(info, "ReferenceNoduleIDs").text = ",".join(
+            [str(e) for e in self.referencenoduleids]
+        )
         return info
 
     @staticmethod
     def from_xml(xml):
-        referencenoduleids = tuple([int(e) for e in xml.find("./ReferenceNoduleIDs").text.split(',')])
+        ref_nodule_ids = xml.find("./ReferenceNoduleIDs").text
+        referencenoduleids = ()
+        if ref_nodule_ids is not None:
+            referencenoduleids = tuple(
+                [int(e) for e in ref_nodule_ids.split(",")]
+            )
         casecancerprobability = float(xml.find("./CaseCancerProbability").text)
-        return CancerInfo(casecancerprobability=casecancerprobability, referencenoduleids=referencenoduleids)
+        return CancerInfo(
+            casecancerprobability=casecancerprobability,
+            referencenoduleids=referencenoduleids,
+        )
 
     def __eq__(self, other):
-        return isinstance(other, type(self)) and \
-               self.referencenoduleids == other.referencenoduleids and \
-               self.casecancerprobability == other.casecancerprobability
+        return (
+            isinstance(other, type(self))
+            and self.referencenoduleids == other.referencenoduleids
+            and self.casecancerprobability == other.casecancerprobability
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __repr__(self):
         return "casecancerprobability: {} referencenoduleids: {}".format(
-            self.casecancerprobability,
-            self.referencenoduleids)
+            self.casecancerprobability, self.referencenoduleids
+        )


### PR DESCRIPTION
Fixes #46

Some cases would fail as mentioned in #46, the xmlreport.py has been updated in https://github.com/DIAGNijmegen/bodyct-nodule-evaluation to version 0.02, which fixes this issue. Since this repo uses Python 2 I have chosen to just copy the source and change it to Python 2 as a patch. After this repository is converted to Python 3, ideally the repository should be added as a private repository pip install instead.

### PR changes

* xmlreport.py
  * Copied https://github.com/DIAGNijmegen/bodyct-nodule-evaluation/pull/21 version
  * Converted to Python 2 compatible version

* Dockerfile
  * Updated code for patching the xmlreport.py

* test_xmlreport.py
  * Updated some failing CancerInfo referencenoduleids (just to make them pass)

### Tests

* [x] All pytests pass
* [x] Running on the previously failed cases works now
* [x] Docker processor builds correctly 